### PR TITLE
Type error in wallet command

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -144,9 +144,6 @@ function transaction(vorpal) {
 function newWallet(vorpal) {
   vorpal
     .command("wallet <password>", "Create a new wallet with <password>")
-    .types({
-      string: 'password'
-    })
     .alias("w")
     .action((args, callback) => {
       args.password = args.password.toString();

--- a/cli.ts
+++ b/cli.ts
@@ -144,8 +144,12 @@ function transaction(vorpal) {
 function newWallet(vorpal) {
   vorpal
     .command("wallet <password>", "Create a new wallet with <password>")
+    .types({
+      string: 'password'
+    })
     .alias("w")
     .action((args, callback) => {
+      args.password = args.password.toString();
       peer.newWallet(args.password);
       const hidePass = args.password.replace(/./g, "*");
       this.log(`Created new wallet with password ${hidePass}.\n`);
@@ -207,8 +211,8 @@ function balance(vorpal) {
     .action((args, callback) => {
       try {
         this.log(peer.getBalance(args.address))
-      } catch(e) {
-        if(e instanceof TypeError) {
+      } catch (e) {
+        if (e instanceof TypeError) {
           handleTypeError.call(this, e);
         }
       } finally {


### PR DESCRIPTION
i try to fix it using the vorpal api but it has not implemented .type for the arguments of .command

[I found the funcion here](https://github.com/dthree/vorpal/blob/604a96682e2345da4dda7ebf26c477350a1b9c6d/dist/command.js#L249) but only validates the type without doing a toString or something similar `this._types` never use again.

so I saw the problem with the type number only occurs in the wallet command because it uses a replace